### PR TITLE
TLS skip verify in wss/watch endpoint

### DIFF
--- a/restapi/ws_handle.go
+++ b/restapi/ws_handle.go
@@ -272,7 +272,8 @@ func newWebSocketS3Client(conn *websocket.Conn, claims *models.Principal, namesp
 	}
 
 	svcURL := GetTenantServiceURL(minTenant)
-	s3Client, err := newTenantS3BucketClient(tenantClaims, svcURL, bucketName, minTenant.TLS())
+	// TODO: change isSecure: true to minTenant.TLS() and add support to S3Client to accept custom TLS Transport
+	s3Client, err := newTenantS3BucketClient(tenantClaims, svcURL, bucketName, false)
 	if err != nil {
 		log.Println("error creating S3Client:", err)
 		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))


### PR DESCRIPTION
Use insecure: true in the meantime so the wss/watch endpoint works while
we add support for custotm TLS transport in the S3 client library.